### PR TITLE
add `before` property to CommentSearchOptions

### DIFF
--- a/src/SearchOptions.ts
+++ b/src/SearchOptions.ts
@@ -8,6 +8,7 @@ export declare interface CommentSearchOptions {
   author?: string;
   subreddit?: string;
   after?: number;
+  before: string;
   frequency?: string;
   metadata?: boolean;
 }

--- a/src/SearchOptions.ts
+++ b/src/SearchOptions.ts
@@ -7,8 +7,8 @@ export declare interface CommentSearchOptions {
   aggs?: string[];
   author?: string;
   subreddit?: string;
-  after?: number;
-  before: string;
+  after?: number | string;
+  before?: number | string;
   frequency?: string;
   metadata?: boolean;
 }


### PR DESCRIPTION
`before` property is missing from the CommentSearchOptions:
https://github.com/pushshift/api